### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
 BIN_DIR := $(shell pwd)/bin
 
 # Tool versions
-MDBOOK_VERSION = 0.4.10
+MDBOOK_VERSION = 0.4.15
 MDBOOK := $(BIN_DIR)/mdbook
 
 # Test tools
 STATICCHECK = $(BIN_DIR)/staticcheck
-NILERR = $(BIN_DIR)/nilerr
 
 .PHONY: all
 all: test
@@ -18,10 +17,15 @@ book: $(MDBOOK)
 
 
 .PHONY: test
-test: test-tools
+test:
+	if find . -name go.mod | grep -q go.mod; then \
+		$(MAKE) test-go; \
+	fi
+
+.PHONY: test-go
+test-go: test-tools
 	test -z "$$(gofmt -s -l . | tee /dev/stderr)"
 	$(STATICCHECK) ./...
-	test -z "$$($(NILERR) ./... 2>&1 | tee /dev/stderr)"
 	go install ./...
 	go test -race -v ./...
 	go vet ./...
@@ -34,12 +38,8 @@ $(MDBOOK):
 	curl -fsL https://github.com/rust-lang/mdBook/releases/download/v$(MDBOOK_VERSION)/mdbook-v$(MDBOOK_VERSION)-x86_64-unknown-linux-gnu.tar.gz | tar -C bin -xzf -
 
 .PHONY: test-tools
-test-tools: $(STATICCHECK) $(NILERR)
+test-tools: $(STATICCHECK)
 
 $(STATICCHECK):
 	mkdir -p $(BIN_DIR)
 	GOBIN=$(BIN_DIR) go install honnef.co/go/tools/cmd/staticcheck@latest
-
-$(NILERR):
-	mkdir -p $(BIN_DIR)
-	GOBIN=$(BIN_DIR) go install github.com/gostaticanalysis/nilerr/cmd/nilerr@latest


### PR DESCRIPTION
- skip testing Go source if there is no `go.mod`
- update mdBook to 0.4.15
- remove `nilerr` due to its incorrectness